### PR TITLE
feat: implement M3 — save runs and history page

### DIFF
--- a/src/app/(dashboard)/history/page.tsx
+++ b/src/app/(dashboard)/history/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import Header from "@/components/shared/Header";
+import RunList from "@/components/history/RunList";
+import type { Run } from "@/lib/types";
 
 export default async function HistoryPage() {
   const supabase = await createClient();
@@ -9,12 +11,18 @@ export default async function HistoryPage() {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
+  const { data: runs } = await supabase
+    .from("runs")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
   return (
     <div className="min-h-screen flex flex-col bg-gray-50">
       <Header userEmail={user.email} />
       <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
-        <h1 className="text-xl font-bold text-gray-900">History</h1>
-        <p className="text-gray-500 mt-2">Coming in M3.</p>
+        <h1 className="text-xl font-bold text-gray-900 mb-6">History</h1>
+        <RunList runs={(runs ?? []) as Run[]} />
       </main>
     </div>
   );

--- a/src/app/(dashboard)/playground/PlaygroundClient.tsx
+++ b/src/app/(dashboard)/playground/PlaygroundClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { ModelOption, ModelResponse, RunResult } from "@/lib/types";
 import { getDemoSession, incrementDemoRun, isDemoLimitReached, DEMO_RUN_LIMIT } from "@/lib/demo";
+import { createClient } from "@/lib/supabase/client";
 import Header from "@/components/shared/Header";
 import DemoBanner from "@/components/shared/DemoBanner";
 import KeyManager from "@/components/shared/KeyManager";
@@ -30,6 +31,9 @@ export default function PlaygroundClient({
   const [scores, setScores] = useState<Record<string, number | null>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const demoSession = isDemo ? getDemoSession() : null;
   const runsUsed = demoSession?.runsUsed ?? 0;
@@ -55,6 +59,8 @@ export default function PlaygroundClient({
     setLoading(true);
     setResponses([]);
     setScores({});
+    setSaved(false);
+    setSaveError(null);
 
     if (isDemo) {
       incrementDemoRun();
@@ -84,6 +90,28 @@ export default function PlaygroundClient({
       setError("Network error. Please try again.");
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveError(null);
+    const responsesWithScores = responses.map((r) => ({
+      ...r,
+      score: scores[r.model] ?? null,
+    }));
+    const supabase = createClient();
+    const { error: dbError } = await supabase.from("runs").insert({
+      system_prompt: systemPrompt,
+      user_message: userMessage,
+      models: selectedModels,
+      responses: responsesWithScores,
+    });
+    setSaving(false);
+    if (dbError) {
+      setSaveError(dbError.message);
+    } else {
+      setSaved(true);
     }
   }
 
@@ -147,21 +175,37 @@ export default function PlaygroundClient({
             )}
 
             {responses.length > 0 && (
-              <div
-                className={`grid gap-4 ${
-                  responses.length === 1 ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2"
-                }`}
-              >
-                {responses.map((r) => (
-                  <ResponseCard
-                    key={r.model}
-                    response={r}
-                    modelName={modelMap[r.model] ?? r.model}
-                    score={scores[r.model] ?? null}
-                    onScore={(s) => setScores((prev) => ({ ...prev, [r.model]: s }))}
-                    isDemo={isDemo}
-                  />
-                ))}
+              <div className="space-y-4">
+                {!isDemo && (
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={handleSave}
+                      disabled={saving || saved}
+                      className="bg-green-600 text-white py-1.5 px-4 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      {saving ? "Saving…" : saved ? "Saved!" : "Save Run"}
+                    </button>
+                    {saveError && (
+                      <p className="text-sm text-red-600">{saveError}</p>
+                    )}
+                  </div>
+                )}
+                <div
+                  className={`grid gap-4 ${
+                    responses.length === 1 ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2"
+                  }`}
+                >
+                  {responses.map((r) => (
+                    <ResponseCard
+                      key={r.model}
+                      response={r}
+                      modelName={modelMap[r.model] ?? r.model}
+                      score={scores[r.model] ?? null}
+                      onScore={(s) => setScores((prev) => ({ ...prev, [r.model]: s }))}
+                      isDemo={isDemo}
+                    />
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/src/components/history/RunCard.tsx
+++ b/src/components/history/RunCard.tsx
@@ -1,3 +1,113 @@
-export default function RunCard() {
-  return null;
+"use client";
+
+import { useState } from "react";
+import type { Run } from "@/lib/types";
+import { SUPPORTED_MODELS } from "@/lib/models";
+
+interface RunCardProps {
+  run: Run;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : text.slice(0, max) + "…";
+}
+
+function modelName(id: string): string {
+  return SUPPORTED_MODELS.find((m) => m.id === id)?.name ?? id;
+}
+
+export default function RunCard({ run }: RunCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const bestScore = run.responses.reduce<number | null>((best, r) => {
+    if (r.score === null) return best;
+    return best === null ? r.score : Math.max(best, r.score);
+  }, null);
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      {/* Collapsed header — always visible */}
+      <div className="px-4 py-3 flex items-start gap-3">
+        <div className="flex-1 min-w-0 space-y-1.5">
+          <p className="text-sm text-gray-800 leading-snug">
+            {truncate(run.user_message, 120)}
+          </p>
+          <div className="flex flex-wrap gap-1.5 items-center">
+            {run.models.map((m) => (
+              <span
+                key={m}
+                className="inline-block bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full"
+              >
+                {modelName(m)}
+              </span>
+            ))}
+            <span className="text-xs text-gray-400 ml-1">
+              Best score: {bestScore !== null ? `${bestScore}/5` : "—"}
+            </span>
+          </div>
+          <p className="text-xs text-gray-400">{formatDate(run.created_at)}</p>
+        </div>
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="shrink-0 text-xs text-blue-600 hover:text-blue-800 mt-0.5"
+        >
+          {expanded ? "Collapse" : "Expand"}
+        </button>
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="border-t border-gray-100 px-4 py-4 space-y-4 bg-gray-50">
+          {run.system_prompt && (
+            <div>
+              <p className="text-xs font-medium text-gray-500 mb-1">System prompt</p>
+              <p className="text-sm text-gray-700 whitespace-pre-wrap">{run.system_prompt}</p>
+            </div>
+          )}
+          <div>
+            <p className="text-xs font-medium text-gray-500 mb-1">User message</p>
+            <p className="text-sm text-gray-700 whitespace-pre-wrap">{run.user_message}</p>
+          </div>
+          <div
+            className={`grid gap-3 ${
+              run.responses.length === 1 ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2"
+            }`}
+          >
+            {run.responses.map((r) => (
+              <div key={r.model} className="bg-white border border-gray-200 rounded-lg">
+                <div className="flex items-center justify-between px-3 py-2 border-b border-gray-100">
+                  <span className="text-xs font-medium text-gray-700">{modelName(r.model)}</span>
+                  <div className="flex items-center gap-2 text-xs text-gray-400">
+                    {r.score !== null && (
+                      <span className="text-blue-600 font-medium">{r.score}/5</span>
+                    )}
+                    <span>{r.latency_ms}ms</span>
+                  </div>
+                </div>
+                <div className="px-3 py-2">
+                  {r.error ? (
+                    <p className="text-xs text-red-600 italic">{r.error}</p>
+                  ) : (
+                    <p className="text-sm text-gray-800 whitespace-pre-wrap leading-relaxed">
+                      {r.response}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/history/RunList.tsx
+++ b/src/components/history/RunList.tsx
@@ -1,3 +1,34 @@
-export default function RunList() {
-  return null;
+import Link from "next/link";
+import type { Run } from "@/lib/types";
+import RunCard from "./RunCard";
+
+interface RunListProps {
+  runs: Run[];
+}
+
+export default function RunList({ runs }: RunListProps) {
+  if (runs.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center border-2 border-dashed border-gray-200 rounded-lg">
+        <p className="text-gray-500 text-sm">No saved runs yet.</p>
+        <p className="text-gray-400 text-sm mt-1">
+          Head to the{" "}
+          <Link href="/playground" className="text-blue-600 hover:underline">
+            Playground
+          </Link>{" "}
+          to run your first prompt.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {runs.map((run) => (
+        <li key={run.id}>
+          <RunCard run={run} />
+        </li>
+      ))}
+    </ul>
+  );
 }


### PR DESCRIPTION
- PlaygroundClient: add Save Run button (auth mode only) that inserts the completed run (with current scores) into Supabase runs table; button disables after a successful save and re-enables on each new run
- history/page.tsx: server component that fetches runs for the authenticated user ordered by created_at DESC, renders RunList
- RunList: maps runs to RunCards; empty state with link to Playground
- RunCard: expandable card showing user message preview, model pills, best score, and timestamp in collapsed view; full system prompt, user message, and per-model responses (with score and latency) in expanded view

https://claude.ai/code/session_01RfFk48FzoyngzfD6p3ip1z