### PR TITLE
Fix auth redirects to /playground and add email confirmation callback

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default async function LoginPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (user) redirect("/");
+  if (user) redirect("/playground");
 
   return (
     <main className="min-h-screen flex items-center justify-center bg-gray-50 px-4">

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (code) {
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          },
+        },
+      }
+    );
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}/playground`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login`);
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -26,7 +26,7 @@ export default function LoginForm() {
       return;
     }
 
-    router.push("/");
+    router.push("/playground");
     router.refresh();
   }
 


### PR DESCRIPTION
- LoginForm: redirect to /playground after sign-in (was /)
- LoginPage: redirect authenticated users to /playground (was /)
- Add /auth/callback route to exchange email confirmation codes for sessions

https://claude.ai/code/session_01RfFk48FzoyngzfD6p3ip1z